### PR TITLE
Fix bug where cloned Neo/Matrix blocks get incorrect LJ Color Picker field values

### DIFF
--- a/src/fields/Spectrum.php
+++ b/src/fields/Spectrum.php
@@ -65,7 +65,7 @@ showAlpha: true';
 		
 		$view->registerJs($js);
 		
-        if ($this->isFresh($element)) {
+        if ($this->isFresh($element) && $value === null) {
             $value = $this->defaultColor;
         };
 


### PR DESCRIPTION
This fixes a bug in the field's `getInputHtml()` method, where the field value is set to the default colour if `$this->isFresh($element)` is true, regardless of whether the `$value` passed into `getInputHtml()` is set or not.  Not also checking whether `$value === null` causes pasted/cloned [Neo](https://plugins.craftcms.com/neo) blocks, and Matrix blocks pasted/cloned using [Smith](https://plugins.craftcms.com/smith), to have the default colour set on the clone block instead of the colour value from the block that was copied/cloned.  This pull request ensures that `$value === null` is checked.

Fixes #1.